### PR TITLE
Improve image upload handling

### DIFF
--- a/admin/upload_handler.php
+++ b/admin/upload_handler.php
@@ -23,6 +23,7 @@ if (!isset($_POST['csrf_token']) || !verifyCSRFToken($_POST['csrf_token'])) {
 // Configuración de carga
 $folder = preg_replace('/[^a-zA-Z0-9_-]/', '', $_POST['folder'] ?? 'products');
 $uploadDir = __DIR__ . '/../assets/images/' . $folder . '/';
+$baseUrl = rtrim(SITE_URL, '/') . '/';
 $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 $maxFileSize = 5 * 1024 * 1024; // 5MB
 $maxFiles = 5;
@@ -167,15 +168,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['images'])) {
                 $resizedPath = $uploadDir . 'thumb_' . $fileName;
                 if (resizeImage($filePath, $resizedPath, 300, 300)) {
                     $uploadedFiles[] = [
-                        'original' => 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => 'assets/images/' . $folder . '/thumb_' . $fileName,
+                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
+                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/thumb_' . $fileName,
                         'name' => $originalName
                     ];
                 } else {
                     // Si no se puede redimensionar, usar la original
                     $uploadedFiles[] = [
-                        'original' => 'assets/images/' . $folder . '/' . $fileName,
-                        'thumbnail' => 'assets/images/' . $folder . '/' . $fileName,
+                        'original' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
+                        'thumbnail' => $baseUrl . 'assets/images/' . $folder . '/' . $fileName,
                         'name' => $originalName
                     ];
                 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -298,8 +298,12 @@ function handleFileUpload(source, preview, folder = 'products') {
             }
             
             showNotification('Imágenes subidas correctamente', 'success');
+            if (data.errors && data.errors.length > 0) {
+                showNotification('Algunas imágenes no se subieron: ' + data.errors.join('; '), 'warning');
+            }
         } else {
-            showNotification('Error al subir imágenes: ' + data.message, 'error');
+            const msg = data.errors && data.errors.length ? data.errors.join('; ') : data.message;
+            showNotification('Error al subir imágenes: ' + msg, 'error');
         }
     })
     .catch(error => {


### PR DESCRIPTION
## Summary
- adjust upload handler to return absolute URLs
- show upload warnings when some images fail

## Testing
- `php test_system.php > /tmp/test_output.html` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6877189a4cb083268a2eebc090a07b79